### PR TITLE
feat: batch upload and per-wall analysis (#9)

### DIFF
--- a/.github/skills/viktor-sdk/references/views.md
+++ b/.github/skills/viktor-sdk/references/views.md
@@ -253,3 +253,101 @@ Example:
 def run_analysis(self, params, **kwargs):
     ...
 ```
+
+---
+
+## Memoize — caching expensive function calls
+
+Use `@vkt.memoize` to cache the result of a slow function. The cached result is
+reused for up to **24 hours** as long as the arguments do not change. This avoids
+re-running the same calculation when the user switches between views or triggers
+a download without changing the input.
+
+**Rules:**
+- Must be a **module-level** function, not a method on `Controller`.
+- All arguments must be **keyword-only** (defined after a bare `*`).
+- Call sites must pass arguments by keyword.
+- In development the local cache is limited to 50 entries (FIFO eviction).
+  In production the storage is unlimited.
+
+**IMPORTANT limitation:** `@vkt.memoize` hashes the arguments to detect changes.
+VIKTOR `FileResource` objects from `params` are **new instances on every render**
+even when the user hasn't changed any files. This means `@vkt.memoize` will
+**always** be a cache miss when the arguments include `FileResource` objects.
+Use `vkt.Storage(scope='session')` instead for file-based inputs (see below).
+
+```python
+import viktor as vkt
+
+
+@vkt.memoize
+def run_heavy_analysis(*, param_a, param_b):
+    # only re-runs when param_a or param_b changes
+    return _do_work(param_a, param_b)
+
+
+class Controller(vkt.Controller):
+
+    @vkt.DataView("Results")
+    def show_results(self, params, **kwargs):
+        result = run_heavy_analysis(param_a=params.a, param_b=params.b)
+        data = vkt.DataGroup(vkt.DataItem("Count", len(result)))
+        return vkt.DataResult(data)
+```
+
+---
+
+## Session Storage — caching file-based results
+
+When uploads (`FileResource` objects) are the input to a long-running analysis,
+use `vkt.Storage(scope='session')` to cache the serialized result. The session
+scope persists for the lifetime of the user's browser tab and is unique per user.
+
+**Pattern — fingerprint → check storage → compute if miss → store → return:**
+
+```python
+import hashlib
+import json
+import viktor as vkt
+
+_FP_KEY   = "analysis_fingerprint"
+_DATA_KEY = "analysis_result"
+
+
+def _fingerprint(files: list) -> str:
+    names = sorted(getattr(f, "filename", "") for f in files)
+    return hashlib.sha256(":".join(names).encode()).hexdigest()
+
+
+def get_or_compute(files: list) -> dict:
+    fp = _fingerprint(files)
+    try:
+        stored_fp = vkt.Storage().get(_FP_KEY, scope="session")
+        if stored_fp.getvalue().decode() == fp:
+            stored = vkt.Storage().get(_DATA_KEY, scope="session")
+            return json.loads(stored.getvalue().decode())
+    except Exception:
+        pass  # cache miss
+
+    result = _run_analysis(files)   # the expensive call
+
+    try:
+        vkt.Storage().set(_FP_KEY,   data=vkt.File.from_data(fp),                  scope="session")
+        vkt.Storage().set(_DATA_KEY, data=vkt.File.from_data(json.dumps(result)),   scope="session")
+    except Exception:
+        pass
+
+    return result
+```
+
+**Key notes:**
+- `vkt.Storage().get(key, scope="session")` raises an exception when the key
+  does not exist — always wrap in `try/except`.
+- `vkt.Storage().set(key, data=vkt.File.from_data(str_or_bytes), scope="session")`
+- Session data is deleted automatically when the browser tab is closed.
+- Requires SDK >= 14.28.0. The `scope='session'` option is only available for
+  `editor` app type and higher.
+- The fingerprint should be based on something stable (filenames, not object
+  identity). Including file sizes adds robustness but requires reading bytes.
+
+

--- a/soft-shell-calculator-ui/tests/test_app_services.py
+++ b/soft-shell-calculator-ui/tests/test_app_services.py
@@ -13,8 +13,11 @@ from pathlib import Path
 from zipfile import ZipFile
 
 from ui_app.services.analysis_service import analyze_uploaded_measurements
+from ui_app.services.analysis_service import analyze_batch_uploaded_measurements
 from ui_app.services.export_service import build_pile_csv
+from ui_app.services.export_service import build_batch_csv_zip
 from ui_app.services.upload_service import load_uploaded_measurements
+from ui_app.services.upload_service import peek_wall_id_from_file_resource
 
 
 class _InMemoryFileHandle:
@@ -147,3 +150,89 @@ class TestExportService:
 
         assert "Retaining wall id" in csv_content
         assert analysis_result.pile_rows[0].pile_id in csv_content
+
+
+class TestBatchAnalysisService:
+    def test_returns_results_for_multiple_zips(self, all_rgp_paths: list[Path]) -> None:
+        """Batch analysis should produce one result per valid uploaded zip."""
+        zip_a = _build_zip_upload(
+            {path.name: _read_file_bytes(path) for path in all_rgp_paths[:3]}
+        )
+        zip_b = _build_zip_upload(
+            {path.name: _read_file_bytes(path) for path in all_rgp_paths[3:6]}
+        )
+        files = [
+            FakeUploadedFile("kade_a.zip", zip_a),
+            FakeUploadedFile("kade_b.zip", zip_b),
+        ]
+
+        batch = analyze_batch_uploaded_measurements(files)
+
+        assert len(batch.wall_results) == 2
+        assert batch.skipped_walls == ()
+
+    def test_skips_invalid_zip_and_continues(self, all_rgp_paths: list[Path]) -> None:
+        """A bad zip in the batch should be skipped; valid ones still analyzed."""
+        valid_zip = _build_zip_upload(
+            {path.name: _read_file_bytes(path) for path in all_rgp_paths[:3]}
+        )
+        invalid_bytes = b"this is not a zip"
+        files = [
+            FakeUploadedFile("geldig.zip", valid_zip),
+            FakeUploadedFile("ongeldig.zip", invalid_bytes),
+        ]
+
+        batch = analyze_batch_uploaded_measurements(files)
+
+        assert len(batch.wall_results) == 1
+        assert "ongeldig.zip" in batch.skipped_walls
+
+
+class TestBatchExportService:
+    def test_build_batch_csv_zip_contains_one_csv_per_wall(
+        self, all_rgp_paths: list[Path]
+    ) -> None:
+        """Batch CSV zip should contain one CSV file per successfully analyzed wall."""
+        zip_a = _build_zip_upload(
+            {path.name: _read_file_bytes(path) for path in all_rgp_paths[:3]}
+        )
+        zip_b = _build_zip_upload(
+            {path.name: _read_file_bytes(path) for path in all_rgp_paths[3:6]}
+        )
+        files = [
+            FakeUploadedFile("kade_a.zip", zip_a),
+            FakeUploadedFile("kade_b.zip", zip_b),
+        ]
+        batch = analyze_batch_uploaded_measurements(files)
+
+        zip_bytes = build_batch_csv_zip(batch)
+
+        with io.BytesIO(zip_bytes) as buf:
+            with ZipFile(buf) as archive:
+                csv_names = archive.namelist()
+
+        assert len(csv_names) == 2
+        assert all(name.endswith(".csv") for name in csv_names)
+
+
+class TestPeekWallId:
+    def test_returns_wall_id_from_valid_zip(self, all_rgp_paths: list[Path]) -> None:
+        """Peek should return the wall ID without running full analysis."""
+        zip_content = _build_zip_upload(
+            {path.name: _read_file_bytes(path) for path in all_rgp_paths[:2]}
+        )
+        uploaded_file = FakeUploadedFile("metingen.zip", zip_content)
+
+        wall_id = peek_wall_id_from_file_resource(uploaded_file)
+
+        assert wall_id is not None
+        assert isinstance(wall_id, str)
+        assert len(wall_id) > 0
+
+    def test_returns_none_for_invalid_zip(self) -> None:
+        """Peek should return None for a file that is not a valid zip."""
+        uploaded_file = FakeUploadedFile("corrupt.zip", b"not a zip")
+
+        wall_id = peek_wall_id_from_file_resource(uploaded_file)
+
+        assert wall_id is None

--- a/soft-shell-calculator-ui/ui_app/controller.py
+++ b/soft-shell-calculator-ui/ui_app/controller.py
@@ -1,16 +1,16 @@
 """Controller definition for the VIKTOR app.
 
 This module should define the output views, download handlers, and the
-high-level interaction flow between the parametrization and the application
-services. The controller should remain thin and delegate real work to the
-service layer.
+high-level interaction flow between the parametrization and the services.
+The controller should remain thin and delegate real work to the service layer.
 """
 
 import viktor as vkt
 
 from ui_app.parametrization import Parametrization
-from ui_app.services.analysis_service import analyze_uploaded_measurements
-from ui_app.services.export_service import build_pile_csv
+from ui_app.services.analysis_service import get_batch
+from ui_app.services.export_service import build_batch_csv_zip
+from ui_app.view_models import BatchAnalysisResult, WallAnalysisResult
 
 
 class Controller(vkt.Controller):
@@ -20,59 +20,62 @@ class Controller(vkt.Controller):
 
     @vkt.DataView("Samenvatting")
     def show_summary(self, params, **kwargs):
-        """Show a wall-level summary for the uploaded measurements."""
-        uploaded_file = self._get_uploaded_file(params)
-        if uploaded_file is None:
+        """Show a wall-level summary for the selected retaining wall."""
+        files = self._get_uploaded_files(params)
+        if not files:
             data = vkt.DataGroup(
+                vkt.DataItem("Status", "Upload meetbestanden om de analyse te starten.")
+            )
+            return vkt.DataResult(data)
+
+        batch = get_batch(files)
+        selected_wall_id = getattr(params.tab_invoer, "geselecteerde_kade", None)
+        wall_result = self._find_wall_result(batch, selected_wall_id)
+
+        if wall_result is None:
+            items = [
+                vkt.DataItem("Geanalyseerde kades", len(batch.wall_results)),
                 vkt.DataItem(
                     "Status",
-                    "Upload een meetbestand om de analyse te starten.",
+                    "Selecteer een kade in het linker paneel om de samenvatting te bekijken.",
+                ),
+            ]
+            if batch.skipped_walls:
+                items.append(
+                    vkt.DataItem(
+                        "Overgeslagen uploads",
+                        ", ".join(batch.skipped_walls),
+                    )
+                )
+            return vkt.DataResult(vkt.DataGroup(*items))
+
+        summary = wall_result.summary
+        skipped_files = (
+            ", ".join(summary.skipped_files) if summary.skipped_files else "Geen"
+        )
+        items = [
+            vkt.DataItem("Bronbestand", summary.source_filename),
+            vkt.DataItem("Kade", summary.retaining_wall_id),
+            vkt.DataItem("Constructiedelen", summary.construction_part_count),
+            vkt.DataItem("Palen", summary.pile_count),
+            vkt.DataItem("Metingen", summary.measurement_count),
+            vkt.DataItem("Geldige bestanden", summary.valid_file_count),
+            vkt.DataItem("Palen met waarschuwing", summary.warning_pile_count),
+            vkt.DataItem("Palen met fout", summary.failed_pile_count),
+            vkt.DataItem("Overgeslagen bestanden", skipped_files),
+        ]
+        if batch.skipped_walls:
+            items.append(
+                vkt.DataItem(
+                    "Overgeslagen uploads",
+                    ", ".join(batch.skipped_walls),
                 )
             )
-            return vkt.DataResult(data)
-
-        try:
-            analysis_result = analyze_uploaded_measurements(uploaded_file)
-        except ValueError as exc:
-            data = vkt.DataGroup(
-                vkt.DataItem("Status", "Analyse mislukt"),
-                vkt.DataItem("Melding", str(exc)),
-            )
-            return vkt.DataResult(data)
-
-        skipped_files = ", ".join(analysis_result.summary.skipped_files)
-        data = vkt.DataGroup(
-            vkt.DataItem("Bronbestand", analysis_result.summary.source_filename),
-            vkt.DataItem("Kade", analysis_result.summary.retaining_wall_id),
-            vkt.DataItem(
-                "Constructiedelen",
-                analysis_result.summary.construction_part_count,
-            ),
-            vkt.DataItem("Palen", analysis_result.summary.pile_count),
-            vkt.DataItem("Metingen", analysis_result.summary.measurement_count),
-            vkt.DataItem(
-                "Geldige bestanden",
-                analysis_result.summary.valid_file_count,
-            ),
-            vkt.DataItem(
-                "Palen met waarschuwing",
-                analysis_result.summary.warning_pile_count,
-            ),
-            vkt.DataItem(
-                "Palen met fout",
-                analysis_result.summary.failed_pile_count,
-            ),
-            vkt.DataItem(
-                "Overgeslagen bestanden",
-                skipped_files if skipped_files else "Geen",
-            ),
-        )
-        return vkt.DataResult(data)
+        return vkt.DataResult(vkt.DataGroup(*items))
 
     @vkt.TableView("Paaloverzicht")
     def show_pile_table(self, params, **kwargs):
-        """Show pile-level results in a tabular overview."""
-        uploaded_file = self._get_uploaded_file(params)
+        """Show pile-level results for the selected retaining wall."""
         column_headers = [
             "Constructiedeel",
             "Paal",
@@ -87,7 +90,9 @@ class Controller(vkt.Controller):
             "Status",
             "Foutmelding",
         ]
-        if uploaded_file is None:
+
+        files = self._get_uploaded_files(params)
+        if not files:
             return vkt.TableResult(
                 [
                     [
@@ -102,17 +107,34 @@ class Controller(vkt.Controller):
                         "",
                         "",
                         "",
-                        "Upload eerst een meetbestand",
+                        "Upload eerst meetbestanden",
                     ]
                 ],
                 column_headers=column_headers,
             )
 
-        try:
-            analysis_result = analyze_uploaded_measurements(uploaded_file)
-        except ValueError as exc:
+        batch = get_batch(files)
+        selected_wall_id = getattr(params.tab_invoer, "geselecteerde_kade", None)
+        wall_result = self._find_wall_result(batch, selected_wall_id)
+
+        if wall_result is None:
             return vkt.TableResult(
-                [["-", "-", "-", "", "", "", "", "", "", "", "Fout", str(exc)]],
+                [
+                    [
+                        "-",
+                        "-",
+                        "-",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "Selecteer een kade in het linker paneel",
+                    ]
+                ],
                 column_headers=column_headers,
             )
 
@@ -131,30 +153,57 @@ class Controller(vkt.Controller):
                 row.status,
                 row.error_message or "",
             ]
-            for row in analysis_result.pile_rows
+            for row in wall_result.pile_rows
         ]
         return vkt.TableResult(table_data, column_headers=column_headers)
 
     def download_csv(self, params, **kwargs):
-        """Return a CSV download for the current pile-level analysis."""
-        analysis_result = analyze_uploaded_measurements(self._get_uploaded_file(params))
-        csv_bytes = build_pile_csv(analysis_result)
+        """Return a zip archive containing one CSV per retaining wall."""
+        files = self._get_uploaded_files(params)
+        batch = get_batch(files)
+        zip_bytes = build_batch_csv_zip(batch)
         return vkt.DownloadResult(
-            file_content=csv_bytes,
-            file_name="soft_shell_calculator_results.csv",
+            file_content=zip_bytes,
+            file_name="soft_shell_calculator_resultaten.zip",
         )
 
     @staticmethod
-    def _get_uploaded_file(params):
-        """Return the uploaded file from the parametrization.
+    def _get_uploaded_files(params) -> list:
+        """Return the list of uploaded files from the parametrization.
 
         Args:
             params: VIKTOR params object.
 
         Returns:
-            Uploaded file resource or `None`.
+            List of uploaded file resources, empty if none uploaded.
         """
-        return getattr(params.tab_invoer, "meetbestand", None)
+        return getattr(params.tab_invoer, "meetbestanden", None) or []
+
+    @staticmethod
+    def _find_wall_result(
+        batch: BatchAnalysisResult, selected_wall_id: str | None
+    ) -> WallAnalysisResult | None:
+        """Find the wall result matching the selected wall ID.
+
+        Falls back to the first alphabetical wall when no selection is made,
+        so results are shown immediately after upload without user interaction.
+
+        Args:
+            batch: Batch analysis result containing all wall results.
+            selected_wall_id: The retaining-wall ID chosen by the user.
+
+        Returns:
+            Matching wall result, first alphabetical wall as fallback, or
+            ``None`` if the batch contains no results.
+        """
+        if not batch.wall_results:
+            return None
+        if selected_wall_id:
+            for result in batch.wall_results:
+                if result.summary.retaining_wall_id == selected_wall_id:
+                    return result
+        # No selection or stale selection — return first alphabetical wall
+        return min(batch.wall_results, key=lambda r: r.summary.retaining_wall_id)
 
     @staticmethod
     def _format_optional_number(value: float | None) -> str:

--- a/soft-shell-calculator-ui/ui_app/parametrization.py
+++ b/soft-shell-calculator-ui/ui_app/parametrization.py
@@ -7,24 +7,51 @@ User-facing labels and help text should be kept in Dutch.
 
 import viktor as vkt
 
+from ui_app.services.upload_service import peek_wall_id_from_file_resource
+
+
+def _get_wall_options(params, **kwargs) -> list[str]:
+    """Return the list of retaining-wall IDs available for selection.
+
+    Args:
+        params: VIKTOR params object.
+
+    Returns:
+        List of wall IDs derived from the uploaded zip filenames.
+    """
+    files = getattr(getattr(params, "tab_invoer", None), "meetbestanden", None) or []
+    options: list[str] = []
+    for uploaded_file in files:
+        wall_id = peek_wall_id_from_file_resource(uploaded_file)
+        if wall_id and wall_id not in options:
+            options.append(wall_id)
+    return sorted(options)
+
 
 class Parametrization(vkt.Parametrization):
     """Top-level VIKTOR parametrization for the soft shell calculator."""
 
     tab_invoer = vkt.Tab("Invoer")
     tab_invoer.uitleg = vkt.Text(
-        "Upload een zip-bestand met .rgp-metingen of een enkel .rgp-bestand. "
-        "De eerste versie toont een samenvatting, een paaloverzicht en een csv-download."
+        "Upload één of meerdere zip-bestanden met .rgp-metingen. "
+        "Elk zip-bestand vertegenwoordigt één kade. "
+        "Na het uploaden kunt u een kade selecteren om de resultaten te bekijken."
     )
-    tab_invoer.meetbestand = vkt.FileField(
-        "Meetbestand",
-        file_types=[".zip", ".rgp"],
-        description="Ondersteunt een zip met .rgp-metingen of een enkel .rgp-bestand.",
+    tab_invoer.meetbestanden = vkt.MultiFileField(
+        "Meetbestanden",
+        file_types=[".zip"],
+        description="Upload één of meerdere zip-bestanden. Elk zip-bestand vertegenwoordigt één kade.",
+    )
+    tab_invoer.geselecteerde_kade = vkt.OptionField(
+        "Geselecteerde kade",
+        options=_get_wall_options,
+        description="Selecteer een kade om de bijbehorende resultaten te bekijken.",
+        autoselect_single_option=True,
     )
 
     tab_resultaten = vkt.Tab("Resultaten")
     tab_resultaten.download_csv = vkt.DownloadButton(
-        "Download csv",
+        "Download csv (alle kades)",
         method="download_csv",
         longpoll=True,
     )

--- a/soft-shell-calculator-ui/ui_app/services/analysis_service.py
+++ b/soft-shell-calculator-ui/ui_app/services/analysis_service.py
@@ -5,7 +5,13 @@ structures for summary views, tables, and exports.
 """
 
 from ui_app.services.upload_service import load_uploaded_measurements
-from ui_app.view_models import PileRow, WallAnalysisResult, WallSummary
+from ui_app.view_models import (
+    BatchAnalysisResult,
+    BatchAnalysisResult,
+    PileRow,
+    WallAnalysisResult,
+    WallSummary,
+)
 from soft_shell_calculator_lib.models.retaining_wall import RetainingWall
 from soft_shell_calculator_lib.models.wooden_pile import WoodenPile
 
@@ -162,3 +168,62 @@ def _build_warning_messages(
     if asymmetric_soft_shell:
         warnings.append("Asymmetrische zachte schil")
     return tuple(warnings)
+
+
+_batch_cache: dict[str, BatchAnalysisResult] = {}
+
+
+def _fingerprint(uploaded_files: list) -> str:
+    """Stable cache key derived from uploaded filenames.
+
+    Args:
+        uploaded_files: List of VIKTOR FileResource-like objects.
+
+    Returns:
+        Sorted, joined filename string used as a cache key.
+    """
+    names = sorted(getattr(f, "filename", "") for f in uploaded_files)
+    return "|".join(names)
+
+
+def get_batch(uploaded_files: list) -> BatchAnalysisResult:
+    """Return cached batch result, computing it on first call per file set.
+
+    Args:
+        uploaded_files: List of VIKTOR FileResource-like objects.
+
+    Returns:
+        Cached or freshly computed batch result.
+    """
+    key = _fingerprint(uploaded_files)
+    if key not in _batch_cache:
+        _batch_cache[key] = analyze_batch_uploaded_measurements(uploaded_files)
+    return _batch_cache[key]
+
+
+def analyze_batch_uploaded_measurements(uploaded_files: list) -> BatchAnalysisResult:
+    """Analyze multiple uploaded zip files, one per retaining wall.
+
+    Files that fail analysis are skipped and recorded in ``skipped_walls``.
+
+    Args:
+        uploaded_files: List of VIKTOR FileResource-like objects.
+
+    Returns:
+        Batch result with per-wall analyses and skipped wall filenames.
+    """
+    wall_results: list[WallAnalysisResult] = []
+    skipped_walls: list[str] = []
+
+    for uploaded_file in uploaded_files:
+        source_filename = getattr(uploaded_file, "filename", "onbekend bestand")
+        try:
+            result = analyze_uploaded_measurements(uploaded_file)
+            wall_results.append(result)
+        except Exception:
+            skipped_walls.append(source_filename)
+
+    return BatchAnalysisResult(
+        wall_results=tuple(wall_results),
+        skipped_walls=tuple(skipped_walls),
+    )

--- a/soft-shell-calculator-ui/ui_app/services/export_service.py
+++ b/soft-shell-calculator-ui/ui_app/services/export_service.py
@@ -4,9 +4,10 @@ This module assembles downloadable artifacts from app-facing result models.
 """
 
 import csv
-from io import StringIO
+from io import BytesIO, StringIO
+from zipfile import ZIP_DEFLATED, ZipFile
 
-from ui_app.view_models import WallAnalysisResult
+from ui_app.view_models import BatchAnalysisResult, WallAnalysisResult
 
 
 def build_pile_csv(analysis_result: WallAnalysisResult) -> bytes:
@@ -90,3 +91,21 @@ def _format_bool(value: bool) -> str:
         `Yes` or `No`.
     """
     return "Yes" if value else "No"
+
+
+def build_batch_csv_zip(batch_result: BatchAnalysisResult) -> bytes:
+    """Build a zip archive containing one CSV file per retaining wall.
+
+    Args:
+        batch_result: Batch analysis result with multiple wall results.
+
+    Returns:
+        Zip archive bytes with one ``<wall_id>.csv`` entry per wall.
+    """
+    buffer = BytesIO()
+    with ZipFile(buffer, "w", compression=ZIP_DEFLATED) as archive:
+        for wall_result in batch_result.wall_results:
+            wall_id = wall_result.summary.retaining_wall_id
+            csv_bytes = build_pile_csv(wall_result)
+            archive.writestr(f"{wall_id}.csv", csv_bytes)
+    return buffer.getvalue()

--- a/soft-shell-calculator-ui/ui_app/services/upload_service.py
+++ b/soft-shell-calculator-ui/ui_app/services/upload_service.py
@@ -13,6 +13,7 @@ from zipfile import BadZipFile, ZipFile
 
 from soft_shell_calculator_lib.models.retaining_wall import RetainingWall
 from soft_shell_calculator_lib.models.rpd_measurement import RPDMeasurement
+from soft_shell_calculator_lib.utils import MeasurementIdentifier
 
 
 @dataclass(frozen=True)
@@ -224,3 +225,28 @@ def _collect_skipped_files(target_dir: Path) -> tuple[str, ...]:
             skipped_files.append(rgp_file.name)
 
     return tuple(skipped_files)
+
+
+def peek_wall_id_from_file_resource(uploaded_file: Any) -> str | None:
+    """Extract the retaining-wall ID from a zip file resource without full analysis.
+
+    Reads the first `.rgp` filename from the zip and parses the wall ID from its
+    stem. Avoids loading any measurement data or constructing domain objects.
+
+    Args:
+        uploaded_file: VIKTOR FileResource-like object.
+
+    Returns:
+        Retaining wall ID or ``None`` if it cannot be determined.
+    """
+    try:
+        file_bytes = _read_uploaded_bytes(uploaded_file)
+        with ZipFile(BytesIO(file_bytes)) as archive:
+            for name in archive.namelist():
+                if name.lower().endswith(".rgp"):
+                    stem = Path(name).stem
+                    identifier = MeasurementIdentifier.from_filename_stem(stem)
+                    return identifier.retaining_wall_id
+    except Exception:
+        return None
+    return None

--- a/soft-shell-calculator-ui/ui_app/view_models.py
+++ b/soft-shell-calculator-ui/ui_app/view_models.py
@@ -76,6 +76,19 @@ class PileRow:
 
 
 @dataclass(frozen=True)
+class BatchAnalysisResult:
+    """Bundle analysis results for multiple uploaded retaining walls.
+
+    Attributes:
+        wall_results: Per-wall analysis results, in upload order.
+        skipped_walls: Source filenames of uploads that could not be analyzed.
+    """
+
+    wall_results: tuple["WallAnalysisResult", ...]
+    skipped_walls: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class WallAnalysisResult:
     """Bundle all app-facing analysis results for one upload.
 


### PR DESCRIPTION
Closes #9

## Changes

- **`MultiFileField`** for uploading multiple `.zip` files, one per retaining wall
- **`OptionField`** (`geselecteerde_kade`) populated dynamically from uploaded filenames; auto-selects when only one wall is uploaded
- **Batch analysis**: `analyze_batch_uploaded_measurements` iterates all uploaded files, skips and records failures
- **Per-wall views**: `show_summary` and `show_pile_table` display results for the selected wall; fall back to first alphabetical wall immediately after upload
- **Batch CSV download**: `download_csv` produces a `.zip` with one `<wall_id>.csv` per wall
- **Module-level cache** (`get_batch`): analysis results are cached by sorted filenames so switching tabs/walls does not re-run the full analysis
- Tests updated to cover batch analysis, batch export, and `peek_wall_id_from_file_resource`